### PR TITLE
add dts to mix package files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -103,6 +103,7 @@ defmodule NervesSystemTrellis.MixProject do
       "linux",
       "rootfs_overlay",
       "uboot",
+      "dts",
       "CHANGELOG.md",
       "fwup-ops.conf",
       "fwup.conf",


### PR DESCRIPTION
The `dts` dir was not part of the mix package files - meaning it wouldn't watch for changes in this directory, nor would it publish properly. 