### PR TITLE
Remove host toolchain configs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.18.3-otp-27
-erlang 27.3.4.2

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,0 @@
-[tools]
-elixir = "1.19.5-otp-28"
-erlang = "28.3"


### PR DESCRIPTION
We don't maintain tool configs in other systems. There should be quite a
bit of flexibility in what is used for Elixir and Erlang since this
project mostly uses Buildroot.
